### PR TITLE
Bypassing GeoIP API key

### DIFF
--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -43,6 +43,14 @@
     dest: /etc/cvmfs/server.local
   when: cvmfs_geo_license_key is defined
 
+- name: Bypassing GeoIP API key
+  ansible.builtin.copy:
+    content: |
+      CVMFS_GEO_DB_FILE=NONE
+    mode: 0400
+    dest: /etc/cvmfs/server.local
+  when: cvmfs_geo_license_key is not defined
+
 - name: Ensure replicas are configured
   ansible.builtin.command: >-
     /usr/bin/cvmfs_server add-replica -o {{ item.owner | default('root') }}


### PR DESCRIPTION
Bypass the "CVMFS_GEO_LICENSE_KEY not set" error message produced by cvmfs_server add-replica by setting the server variable "CVMFS_GEO_DB_FILE to NONE" .