### PR TITLE
Add dependency packages on debian installation for stratum 0 and 1

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -12,8 +12,10 @@ cvmfs_packages:
     - apache2
     - cvmfs-server
     - cvmfs-config-default
+    - cvmfs
   stratum1:
     - apache2
+    - libapache2-mod-wsgi
     - cvmfs-server
     - cvmfs-config-default
   localproxy:


### PR DESCRIPTION
Compared to the installation of redhat system the installation of the packages for startum0 and 1 is not complete on debian installation.