### PR TITLE
fix: missing libapache2-mod-wsgi for Debian based distro

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -15,7 +15,7 @@ cvmfs_packages:
     - cvmfs
   stratum1:
     - apache2
-    - "{{ 'libapache2-mod-wsgi-py3' if ansible_distribution_release in ('bookworm', 'jammy','bullseye') else 'libapache2-mod-wsgi' }}"
+    - "{{ 'libapache2-mod-wsgi' if ansible_distribution_release in ('buster', 'focal') else 'libapache2-mod-wsgi-py3' }}"
     - squid
     - cvmfs-server
     - cvmfs-config-default

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -15,7 +15,7 @@ cvmfs_packages:
     - cvmfs
   stratum1:
     - apache2
-    - libapache2-mod-wsgi
+    - "{{ 'libapache2-mod-wsgi-py3' if ansible_distribution_release in ('bookworm', 'jammy','bullseye') else 'libapache2-mod-wsgi' }}"
     - squid
     - cvmfs-server
     - cvmfs-config-default


### PR DESCRIPTION
the default package "libapache2-mod-wsgi" depend on the distribution system installed 
https://packages.debian.org/search?keywords=libapache2-mod-wsgi
we can add another controller with kernel version it's seems more convesly 
`ansible_kernel  ('4.15', '<')`