### PR TITLE
Change Apache listen port in ports.conf for Debian

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,6 +1,6 @@
 ---
 cvmfs_apache_service_name: apache2
-cvmfs_apache_conf_file: /etc/apache2/apache2.conf
+cvmfs_apache_conf_file: /etc/apache2/ports.conf
 
 cvmfs_squid_service_name: squid
 cvmfs_squid_conf_file: /etc/squid/squid.conf


### PR DESCRIPTION
The Listen configuration is in /etc/apache2/ports.conf in Debian-based systems. From what I can tell, this has been true at least since Debian 4.0 (Etch).