### PR TITLE
Updated management of cernvm.gpg key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file for galaxyproject.cvmfs
 
 cvmfs_apt_repository: "deb [allow-insecure=true] https://cvmrepo.s3.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
+# cvmfs_apt_repository: "deb [signed-by=/etc/apt/keyrings/cernvm.gpg] https://cvmrepo.s3.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
+cvmfs_apt_repository_key: "https://cvmrepo.s3.cern.ch/cvmrepo/apt/cernvm.gpg"
 
 cvmfs_keys: []
 cvmfs_private_keys: []

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -6,8 +6,10 @@
       - ca-certificates
 
 - name: Install CernVM apt key
-  ansible.builtin.apt_key:
-    url: https://cvmrepo.s3.cern.ch/cvmrepo/apt/cernvm.gpg
+  ansible.builtin.get_url:
+    url: "{{ cvmfs_apt_repository_key }}"
+    dest: /etc/apt/keyrings/cernvm.gpg
+    mode: '0644'
 
 - name: Configure CernVM apt repository
   ansible.builtin.apt_repository:

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -5,6 +5,14 @@
       - apt-transport-https
       - ca-certificates
 
+- name: Make sure /etc/apt/keyrings is present
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Install CernVM apt key
   ansible.builtin.get_url:
     url: "{{ cvmfs_apt_repository_key }}"


### PR DESCRIPTION
The apt-key command is deprecated, and I wonder if this is related to the fact that the cernvm.gpg file is no longer downloaded.

Based on https://wiki.debian.org/DebianRepository/UseThirdParty, this PR downloads the cernvm.gpg file to `/etc/apt/keyrings/` and `signed-by=/etc/apt/keyrings/cernvm.gpg` should be added to the repository URL. 

I have not changed the default value for `cvmfs_apt_repository` in order to avoid any issues on systems currently in production, but `signed-by` should be used instead of `allow-insecure`.
